### PR TITLE
Another fix (sorry for multiple pull-request) for Italian

### DIFF
--- a/translator-months-dictionary-Italian.dict
+++ b/translator-months-dictionary-Italian.dict
@@ -30,7 +30,7 @@
 \providetranslation{Tuesday}{marted\`i}
 \providetranslation{Wednesday}{mercoled\`i}
 \providetranslation{Thursday}{gioved\`i}
-\providetranslation{Friday}{venerdi\`i}
+\providetranslation{Friday}{venerd\`i}
 \providetranslation{Saturday}{sabato}
 \providetranslation{Sunday}{domenica}
 

--- a/translator-months-dictionary-Italian.dict
+++ b/translator-months-dictionary-Italian.dict
@@ -26,7 +26,7 @@
 \providetranslation{Nov}{nov}
 \providetranslation{Dec}{dic}
 
-\providetranslation{Monday}{Luned\`i}
+\providetranslation{Monday}{luned\`i}
 \providetranslation{Tuesday}{marted\`i}
 \providetranslation{Wednesday}{mercoled\`i}
 \providetranslation{Thursday}{gioved\`i}


### PR DESCRIPTION
Also "Monday" had a typo in its translation (was capitalised, whereas all the other weekdays weren't).