### PR TITLE
Fix a syntax error in the Bulgarian.dict

### DIFF
--- a/translator-basic-dictionary-Bulgarian.dict
+++ b/translator-basic-dictionary-Bulgarian.dict
@@ -36,7 +36,7 @@
 \providetranslation{Index}{Индекс}
 \providetranslation{Introduction}{Въведение}
 \providetranslation{introduction}{въведение}
-\providetranslation{List of Figures and Tables}{Списък на графики и таблици}figures et des tableaux}
+\providetranslation{List of Figures and Tables}{Списък на графики и таблици}
 \providetranslation{List of Figures}{Списък на фигурите}
 \providetranslation{List of Tables}{Списък на таблиците}
 \providetranslation{or}{или}


### PR DESCRIPTION
There is a syntax error which results in errors when compiling documents written in Bulgarian.
The following patch has to be applied in order to resolve the issue:

--- /usr/share/texmf-dist/tex/latex/translator/translator-basic-dictionary-Bulgarian.dict	2019-07-11 10:28:32.798255831 +0300
+++ /usr/share/texmf-dist/tex/latex/translator/translator-basic-dictionary-Bulgarian.dict	2019-05-11 08:59:34.000000000 +0300
@@ -36,7 +36,7 @@
 \providetranslation{Index}{Индекс}
 \providetranslation{Introduction}{Въведение}
 \providetranslation{introduction}{въведение}
+\providetranslation{List of Figures and Tables}{Списък на графики и таблици}
-\providetranslation{List of Figures and Tables}{Списък на графики и таблици}figures et des tableaux}
 \providetranslation{List of Figures}{Списък на фигурите}
 \providetranslation{List of Tables}{Списък на таблиците}
 \providetranslation{or}{или}


I think the error has been around in the past couple of years and would be grateful if it could be resolved.
Thank you in advance!