### PR TITLE
Fixed "July" translation into Italian.

### DIFF
--- a/translator-months-dictionary-Italian.dict
+++ b/translator-months-dictionary-Italian.dict
@@ -6,7 +6,7 @@
 \providetranslation{April}{aprile}
 \providetranslation{May}{maggio}
 \providetranslation{June}{giugno}
-\providetranslation{July}{July}
+\providetranslation{July}{luglio}
 \providetranslation{August}{agosto}
 \providetranslation{September}{settembre}
 \providetranslation{October}{ottobre}


### PR DESCRIPTION
For some reasons, the month of July had been left in English.